### PR TITLE
The giant race patch

### DIFF
--- a/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
+++ b/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
@@ -73,24 +73,22 @@
 			
 			<!--Giant size prevents use of loadbearing gear, and reasonably, shields.-->
 			
-			<!--Comps at the end because I am 100% sure the basepawn name type is going to change, and putting it here should prevent it from breaking as badly when that happens-->
-			
 			<li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+                    <xpath>/Defs/ThingDef[@Name="GI_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
                     <value>
                         <li>CombatExtended.ITab_Inventory</li>
                     </value>
 			</li>
 
             <li Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
+                    <xpath>/Defs/ThingDef[@Name="GI_PawnBase"]/comps</xpath>
                     <value>
                         <li Class="CombatExtended.CompProperties_Inventory" />
                     </value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
+				<xpath>/Defs/ThingDef[@Name="GI_PawnBase"]/comps</xpath>
 				<value>
 					<li>
 					<compClass>CombatExtended.CompPawnGizmo</compClass>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
