### PR TITLE
Fsx boom changes

### DIFF
--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -30,7 +30,7 @@
 			<li>DrugLab</li>
 		</recipeUsers>		
 		<products>
-			<FSX>10</FSX>
+			<FSX>7</FSX>
 		</products>
 	</RecipeDef>
 
@@ -46,7 +46,7 @@
 				<li>Chemfuel</li>
 			</thingDefs>
 		</filter>
-		<count>80</count>
+		<count>100</count>
 		</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -54,7 +54,7 @@
 			<li>Chemfuel</li>		
 		</thingDefs>		
 		</fixedIngredientFilter>
-		<workAmount>800</workAmount>
+		<workAmount>850</workAmount>
 		<workSkill>Crafting</workSkill>		
 		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>
@@ -63,7 +63,7 @@
 			<li>BiofuelRefinery</li>
 		</recipeUsers>		
 		<products>
-			<FSX>10</FSX>
+			<FSX>8</FSX>
 		</products>
 	</RecipeDef>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -213,7 +213,7 @@
 		<xpath>Defs/ThingDef[defName="Boomalope"]</xpath>
 		<value>
 			<butcherProducts>
-			<FSX>10</FSX>
+			<FSX>6</FSX>
 			</butcherProducts>
 		</value>
 	</Operation>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
